### PR TITLE
Fix MCP server and dataset helpers for agent use

### DIFF
--- a/python/vitaldb-pypi/vitaldb/dataset.py
+++ b/python/vitaldb-pypi/vitaldb/dataset.py
@@ -28,13 +28,13 @@ def load_clinical_data(caseids=[], params=[]):
     global dfci
     if dfci is None:
         dfci = pd.read_csv(f"{api_url}/cases")
-    
-    res = None
+
     if not caseids:
         res = dfci
-    res = dfci[dfci["caseid"].isin(caseids)]
+    else:
+        res = dfci[dfci["caseid"].isin(caseids)]
     if params:
-        existing_params = [param for param in params if param in dfci.columns]
+        existing_params = [param for param in params if param in res.columns]
         res = res[existing_params]
     return res
 
@@ -51,13 +51,13 @@ def load_lab_data(caseids=[], params=[]):
     global dflabs
     if dflabs is None:
         dflabs = pd.read_csv(f"{api_url}/labs")
-    
-    res = None
+
     if not caseids:
         res = dflabs
-    res = dflabs[dflabs["caseid"].isin(caseids)]
+    else:
+        res = dflabs[dflabs["caseid"].isin(caseids)]
     if params:
-        existing_params = [param for param in params if param in dfci.columns]
+        existing_params = [param for param in params if param in res.columns]
         res = res[existing_params]
     return res
 
@@ -147,7 +147,8 @@ def get_track_names(caseids=[]):
     if dftrks is None:
         dftrks = pd.read_csv(f"{api_url}/trks")
 
-    return dftrks[dftrks['caseid'].isin(caseids)].groupby('caseid')["tname"].apply(list).reset_index(name="tnames")
+    res = dftrks if not caseids else dftrks[dftrks['caseid'].isin(caseids)]
+    return res.groupby('caseid')["tname"].apply(list).reset_index(name="tnames")
 
 def find_cases(track_names):
     """Return a list of caseID for cases with the given tracklist.

--- a/python/vitaldb-pypi/vitaldb/mcp_server.py
+++ b/python/vitaldb-pypi/vitaldb/mcp_server.py
@@ -1,11 +1,24 @@
 """VitalDB MCP Server - Model Context Protocol server for VitalDB Python library."""
 
 import json
+
+import numpy as np
 from mcp.server.fastmcp import FastMCP
 
 import vitaldb
 
 mcp = FastMCP("vitaldb")
+
+
+def _safe_list(arr):
+    """Convert an array to a JSON-safe nested list.
+
+    Physiological tracks are full of gaps, which arrive as NaN. json.dumps
+    emits those as bare ``NaN`` tokens, which are invalid JSON (RFC 8259) and
+    reject in strict MCP clients. Replace every non-finite value with null.
+    """
+    arr = np.asarray(arr, dtype=float)
+    return np.where(np.isfinite(arr), arr, None).tolist()
 
 
 @mcp.tool()
@@ -40,7 +53,7 @@ def load_case(caseid: int, track_names: str, interval: float = 1.0) -> str:
     return json.dumps({
         "shape": list(data.shape),
         "columns": track_names.split(","),
-        "data": data.tolist()
+        "data": _safe_list(data)
     })
 
 
@@ -88,6 +101,8 @@ def get_track_names() -> str:
         JSON array of track names
     """
     result = vitaldb.get_track_names()
+    if hasattr(result, "to_json"):        # DataFrame, not a plain list
+        return result.to_json(orient="records")
     return json.dumps(result)
 
 
@@ -103,11 +118,14 @@ def filelist(bedname: str = "", dtstart: str = "", dtend: str = "") -> str:
     Returns:
         JSON array of file information
     """
-    result = vitaldb.filelist(
-        bedname=bedname if bedname else None,
-        dtstart=dtstart if dtstart else None,
-        dtend=dtend if dtend else None
-    )
+    try:
+        result = vitaldb.filelist(
+            bedname=bedname if bedname else None,
+            dtstart=dtstart if dtstart else None,
+            dtend=dtend if dtend else None
+        )
+    except Exception as e:
+        return json.dumps({"error": str(e)})
     if result is None:
         return json.dumps({"error": "Failed to get file list. Login may be required."})
     return json.dumps(result)
@@ -125,11 +143,14 @@ def tracklist(bedname: str = "", dtstart: str = "", dtend: str = "") -> str:
     Returns:
         JSON array of track information
     """
-    result = vitaldb.tracklist(
-        bedname=bedname if bedname else None,
-        dtstart=dtstart if dtstart else None,
-        dtend=dtend if dtend else None
-    )
+    try:
+        result = vitaldb.tracklist(
+            bedname=bedname if bedname else None,
+            dtstart=dtstart if dtstart else None,
+            dtend=dtend if dtend else None
+        )
+    except Exception as e:
+        return json.dumps({"error": str(e)})
     if result is None:
         return json.dumps({"error": "Failed to get track list. Login may be required."})
     return json.dumps(result)
@@ -150,18 +171,21 @@ def receive(bedname: str = "", track_names: str = "", dtstart: str = "", dtend: 
     """
     track_list = [x.strip() for x in track_names.split(",") if x.strip()] if track_names else None
 
-    result = vitaldb.receive(
-        bedname=bedname if bedname else None,
-        track_names=track_list,
-        dtstart=dtstart if dtstart else None,
-        dtend=dtend if dtend else None
-    )
+    try:
+        result = vitaldb.receive(
+            bedname=bedname if bedname else None,
+            track_names=track_list,
+            dtstart=dtstart if dtstart else None,
+            dtend=dtend if dtend else None
+        )
+    except Exception as e:
+        return json.dumps({"error": str(e)})
     if result is None:
         return json.dumps({"error": "Failed to receive data. Login may be required."})
 
     # Convert numpy array to JSON-serializable format
     if hasattr(result, 'tolist'):
-        return json.dumps({"data": result.tolist()})
+        return json.dumps({"data": _safe_list(result)})
     return json.dumps(result)
 
 
@@ -209,9 +233,12 @@ def read_vital(filepath: str, track_names: str = "", interval: float = 1.0) -> s
         }
 
         for track_name in track_list:
-            samples = vf.get_samples(track_name, interval)
-            if samples is not None:
-                result["tracks"][track_name] = samples.tolist()
+            # VitalFile.get_samples returns (rows, columns); rows[i] holds the
+            # samples for the i-th requested track. Calling .tolist() on the
+            # tuple raised for every input.
+            rows, _cols = vf.get_samples(track_name, interval)
+            if rows:
+                result["tracks"][track_name] = _safe_list(rows[0])
 
         return json.dumps(result)
     except Exception as e:


### PR DESCRIPTION
Running the MCP server end to end (all 13 tools, driven over stdio) surfaced several defects that make it unreliable for an AI agent. Every fix is on an empty/default or error path; callers that pass explicit arguments are unaffected. Verified against `api.vitaldb.net`.

## `dataset.py`

- **`load_clinical_data()` / `load_lab_data()` returned 0 rows by default.** The "no caseids → all rows" branch was dead:
  ```python
  res = None
  if not caseids:
      res = dfci
  res = dfci[dfci["caseid"].isin(caseids)]   # overwrites the line above
  ```
  With the default `caseids=[]` this returned `df[df.caseid.isin([])]` = zero rows, contradicting the docstring, and raised nothing. An agent cannot tell "no data" from "no matches".
- **`load_lab_data()` filtered `params` against the clinical columns** (`dfci`) instead of the lab frame, so a valid request like `['name','result']` returned zero columns. Now filters against the result frame.
- **`get_track_names()` had the same empty-list problem**, returning 0 rows when called with no caseids.

## `mcp_server.py`

- **`get_track_names` returned a DataFrame to `json.dumps`** → `Object of type DataFrame is not JSON serializable`. This is the first call an agent makes to discover what exists, and it always failed. Serialise with `to_json` when the value is a DataFrame.
- **`load_case` / `receive` / `read_vital` emitted `NaN` tokens.** Physiological tracks are full of gaps, which serialise as bare `NaN` — invalid per RFC 8259 and rejected by strict JSON parsers. Added `_safe_list()` to map non-finite values to `null`. (One small single-track `load_case` payload contained 6,094 `NaN` tokens.)
- **`read_vital` was broken for every input.** It called `.tolist()` on the `(rows, columns)` tuple that `VitalFile.get_samples` returns → `'tuple' object has no attribute 'tolist'`. Now uses `rows[0]`.
- **`filelist` / `tracklist` / `receive` crashed when not logged in.** `"Please login first"` propagated as an exception, so the tool call errored out, while `download_vital` already returns a clean `{"error": ...}` in the same situation. Made the other three consistent.

## Testing

Exercised all 13 tools over stdio against a pristine `1.7.2` install and this branch:

| | pristine 1.7.2 | this branch |
|---|---|---|
| `get_track_names` | crash (DataFrame) | ok |
| `load_clinical_data()` / `load_lab_data()` default | 0 rows | full table |
| `load_lab_data([1], ['name','result'])` | (114, **0**) | (114, 2) |
| `load_case` / `receive` JSON | contains `NaN` | strict-parseable |
| `read_vital` | fails for all files | returns data |
| `filelist` / `tracklist` / `receive` (no login) | crash | `{"error": ...}` |

Existing happy paths (`find_cases`, `load_case` with explicit tracks, `vital_to_csv`, …) are unchanged.

## Out of scope (kept separate)

Input-validation gaps found in the same pass, left for follow-up so this PR stays focused: `load_case` accepts an unknown/empty track name and returns a silent all-`null` column; an out-of-range `caseid` surfaces a raw HTTP 403; `interval=0` raises `ZeroDivisionError`.